### PR TITLE
Better image handling for WP images

### DIFF
--- a/assets/sass/app.scss
+++ b/assets/sass/app.scss
@@ -59,6 +59,18 @@ body { }
 .hentry footer { }
 
 
+/* ==========================================================================
+   Images
+   ========================================================================== */
+
+img[class*="align"],
+img[class*="wp-image-"],
+img[class*="attachment-"],
+.wp-caption {
+   @include img-responsive();
+}
+
+
 
 /* ==========================================================================
    Footer
@@ -74,8 +86,7 @@ body { }
    ========================================================================== */
 
 .aligncenter { display: block; margin: 0 auto; }
-.alignleft { float: left; }
-.alignright { float: right; }
+.alignleft, .alignright { margin-bottom: 20px; }
 figure.alignnone { margin-left: 0; margin-right: 0; }
 
 
@@ -86,6 +97,9 @@ figure.alignnone { margin-left: 0; margin-right: 0; }
 
 @media (min-width: $screen-sm-min) { }
 
-@media (min-width: $screen-md-min) { }
+@media (min-width: $screen-md-min) {   
+   .alignleft { float: left; margin: 0 10px 20px 0; }
+   .alignright { float: right; margin: 0 0 20px 20px; }
+}
 
 @media (min-width: $screen-lg-min) { }


### PR DESCRIPTION
Add responsiveness and remove WP floats on .align\* classes on small screens.

When using WordPress' theme unit test data, large images are overlapping the content area.
